### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ To install, add the following lines to your `netlify.toml` file:
 package = "netlify-plugin-gatsby-cache"
 ```
 
+Note: The `[[plugins]]` line is required for each plugin, even if you have other plugins in your `netlify.toml` file already.
+
 This plugin determines the location of your `.cache` folder by looking at the `publish` folder configured for Netlify deployment (this can be set in your `netlify.toml` in the `[build]` section). This means that if your Gatsby site successfully deploys, it will be cached as well with no config required! 🎉
 
 ## How much of a difference does this plugin make in build times?

--- a/README.md
+++ b/README.md
@@ -2,33 +2,18 @@
 
 Persist the Gatsby cache between Netlify builds for huge build speed improvements! ⚡️
 
-> NOTE: Netlify Build Plugins are in beta. [To use this plugin, request an invite!](https://www.netlify.com/build/plugins-beta/?utm_source=github&utm_medium=netlify-plugin-gatsby-cache-jl&utm_campaign=devex)
+> NOTE: [Netlify Build Plugins](https://docs.netlify.com/configure-builds/plugins/?utm_source=github&utm_medium=netlify-plugin-gatsby-cache-jl&utm_campaign=devex) are in beta.
 
 ## Usage
 
-First, install the plugin in your repo:
+To install, add the following lines to your `netlify.toml` file:
 
-```bash
-# using npm
-npm install netlify-plugin-gatsby-cache
-
-# or using Yarn
-yarn add netlify-plugin-gatsby-cache
+```toml
+[[plugins]]
+package = "netlify-plugin-gatsby-cache"
 ```
 
-Add the plugin in your `netlify.yml`:
-
-```diff
-  build:
-    command: yarn build
-    publish: public
-    functions: functions
-
-+ plugins:
-+   - type: netlify-plugin-gatsby-cache
-```
-
-This plugin determines the location of your `.cache` folder by looking a the `publish` folder configured for Netlify deployment (this is typically set in your `netlify.yml`/`netlify.toml` in the `build` section). This means that if your Gatsby site successfully deploys, it will be cached as well with no config required! 🎉
+This plugin determines the location of your `.cache` folder by looking at the `publish` folder configured for Netlify deployment (this can be set in your `netlify.toml` in the `[build]` section). This means that if your Gatsby site successfully deploys, it will be cached as well with no config required! 🎉
 
 ## How much of a difference does this plugin make in build times?
 


### PR DESCRIPTION
For greater simplicity and consistency with Netlify users’ existing configuration files, we’re deprecating experimental support for Netlify config files in YAML or JSON (https://github.com/netlify/build/issues/975).

To get new plugin users started on the right foot, I’m proposing updates for all plugin READMEs to use `netlify.toml` format in the installation instructions.

**This docs-only change should require no updates to your plugin code.**

I've also made the following updates to reflect the current plugins API:
- Replaced `type` with `package`.
- Removed the `npm install` step. This is no longer necessary.

I also changed the link to point to a new docs page that will be published tomorrow. I don't know if your utm codes are useful there, but I carried them over into the new link.