### PR TITLE
fix: improve log message

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = () => {
       if (await utils.cache.save(cacheDirs)) {
         console.log('Stored the Gatsby cache to speed up future builds.');
       } else {
-        console.log('Something went wrong storing the cache.');
+        console.log('No Gatsby build found.');
       }
     },
   };


### PR DESCRIPTION
When `utils.cache.save()` returns `false`, it means that no Gatsby build was found locally (so nothing was cached). This could happen for example if the user forgot to run `gatsby build`.

The current message is `Something went wrong storing the cache.` which is unclear whether the problem was caused by the user, the plugin or Netlify. This PR replaces it to `No Gatsby build found.` which should indicate more precisely to the user what is wrong and how to fix the issue.