### PR TITLE
feat: use new Netlify API

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,30 +1,27 @@
 const path = require('path');
 
 const getCacheDirs = constants => [
-  constants.BUILD_DIR,
-  path.normalize(`${constants.BUILD_DIR}/../.cache`),
+  constants.PUBLISH_DIR,
+  path.normalize(`${constants.PUBLISH_DIR}/../.cache`),
 ];
 
-module.exports = () => {
-  return {
-    name: 'netlify-plugin-gatsby-cache',
-    async onPreBuild({ constants, utils }) {
-      const cacheDirs = getCacheDirs(constants);
+module.exports = {
+  async onPreBuild({ constants, utils }) {
+    const cacheDirs = getCacheDirs(constants);
 
-      if (await utils.cache.restore(cacheDirs)) {
-        console.log('Found a Gatsby cache. We’re about to go FAST. ⚡️');
-      } else {
-        console.log('No Gatsby cache found. Building fresh.');
-      }
-    },
-    async onPostBuild({ constants, utils }) {
-      const cacheDirs = getCacheDirs(constants);
+    if (await utils.cache.restore(cacheDirs)) {
+      console.log('Found a Gatsby cache. We’re about to go FAST. ⚡️');
+    } else {
+      console.log('No Gatsby cache found. Building fresh.');
+    }
+  },
+  async onPostBuild({ constants, utils }) {
+    const cacheDirs = getCacheDirs(constants);
 
-      if (await utils.cache.save(cacheDirs)) {
-        console.log('Stored the Gatsby cache to speed up future builds.');
-      } else {
-        console.log('Something went wrong storing the cache.');
-      }
-    },
-  };
+    if (await utils.cache.save(cacheDirs)) {
+      console.log('Stored the Gatsby cache to speed up future builds.');
+    } else {
+      console.log('Something went wrong storing the cache.');
+    }
+  },
 };

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,2 @@
+name: netlify-plugin-gatsby-cache
+inputs: []

--- a/package.json
+++ b/package.json
@@ -4,7 +4,14 @@
   "description": "Persist the Gatsby cache between Netlify builds for huge build speed improvements!",
   "main": "index.js",
   "repository": "https://github.com/jlengstorf/netlify-plugin-gatsby-cache.git",
+  "bugs": {
+    "url": "https://github.com/jlengstorf/netlify-plugin-gatsby-cache/issues"
+  },
   "author": "Jason Lengstorf <jason@lengstorf.com> (https://lengstorf.com)",
   "license": "MIT",
+  "keywords": [
+    "netlify",
+    "netlify-plugin"
+  ],
   "dependencies": {}
 }


### PR DESCRIPTION
Thanks a lot for creating this Build plugin!

Netlify just released the latest version of Build plugins. Build plugins are currently enabled in the Netlify website for a small percentage of beta users.

This PR upgrades this plugin to the latest API. You can find the new documentation [here](https://github.com/netlify/build/blob/master/README.md).

List of the changes:
  - Added `keywords` to `package.json` to make it easier for users to find your plugin
  - Added a `bugs` keyword to `package.json` which will be printed to users if a bug happens inside your plugin
  - Avoid plugin's top-level function since this is not currently used by this plugin
  - Remove the `name` property, which has been removed from Netlify
  - The `BUILD_DIR` constant was renamed to [`PUBLISH_DIR` constant](https://github.com/netlify/build#error-reporting)
  - Add a [`manifest.yml`](https://github.com/netlify/build#anatomy-of-a-plugin)

Thanks!