### PR TITLE
chore: turn build stats into table

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,10 @@ This plugin determines the location of your `.cache` folder by looking at the `p
 
 Each Gatsby site is different, so build times vary widely between them, but one common slowdown in Gatsby builds is processing and transforming images. Gatsby is smart enough to check if these transformations have already been done and skip them, but in order to get that benefit in a build pipeline (e.g. Netlify) the `public` and `.cache` directories need to be preserved between builds. That’s what this plugin does!
 
-On a site with 231 GraphQL queries, 1,871 images, and 224 pages, build times dropped by 75%:
-
-- no cache: ✔  Netlify Build completed in 293207ms ([build log](https://app.netlify.com/sites/lengstorf/deploys/5dceed27d58a580008daaccc))
-cache: ✔  Netlify Build completed in 72835ms ([build log](https://app.netlify.com/sites/lengstorf/deploys/5dcef2463da4810008d48aaa))
-
-On a small site (5 GraphQL queries, no image processing, 32 pages), build times dropped by 30% when using this plugin:
-
- no cache: :heavy_check_mark:  Netlify Build completed in 22072ms ([build log](https://app.netlify.com/sites/build-plugin-test/deploys/5dceed49e746a200091c76fe))
-- cache: :heavy_check_mark:  Netlify Build completed in 15543ms ([build log](https://app.netlify.com/sites/build-plugin-test/deploys/5dceedbfad95d0000bcd46d1))
+|                                                            | No Cache                                                                                                | Cache                                                                                                   | Savings |
+|------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|---------|
+| * 231 GraphQL queries<br>* 1,871 images<br>* 224 pages     | 293207ms ([build log](https://app.netlify.com/sites/lengstorf/deploys/5dceed27d58a580008daaccc))        | 72835ms ([build log](https://app.netlify.com/sites/lengstorf/deploys/5dcef2463da4810008d48aaa))         | 75%     |
+| * 5 GraphQL queries<br>* No image processing<br>* 32 pages | 22072ms ([build log](https://app.netlify.com/sites/build-plugin-test/deploys/5dceed49e746a200091c76fe)) | 15543ms ([build log](https://app.netlify.com/sites/build-plugin-test/deploys/5dceedbfad95d0000bcd46d1)) | 30%     |
 
 tl;dr: Repeat builds with lots of images will be _much_ faster. With few or no images, the difference will be there, but it won’t be as pronounced.
 


### PR DESCRIPTION
I think having the build stats as a table makes them much easier to read and reason about.

Great work on the plugin!